### PR TITLE
Android separator lines

### DIFF
--- a/android/src/main/java/com/zyu/ReactWheelCurvedPicker.java
+++ b/android/src/main/java/com/zyu/ReactWheelCurvedPicker.java
@@ -57,8 +57,8 @@ public class ReactWheelCurvedPicker extends WheelCurvedPicker {
 
         Paint paint = new Paint();
         paint.setColor(Color.WHITE);
-        int colorFrom = 0x00FFFFFF;//Color.BLACK;
-        int colorTo = Color.WHITE;
+        int colorFrom = Color.GRAY;
+        int colorTo = Color.GRAY;
         LinearGradient linearGradientShader = new LinearGradient(rectCurItem.left, rectCurItem.top, rectCurItem.right/2, rectCurItem.top, colorFrom, colorTo, Shader.TileMode.MIRROR);
         paint.setShader(linearGradientShader);
         canvas.drawLine(rectCurItem.left, rectCurItem.top, rectCurItem.right, rectCurItem.top, paint);


### PR DESCRIPTION
Make android separator lines gray instead of white - same as iOS